### PR TITLE
feat: Add methods for reading all properties at once

### DIFF
--- a/src/DBus.Services.Secrets/Collection.cs
+++ b/src/DBus.Services.Secrets/Collection.cs
@@ -9,6 +9,46 @@ using Tmds.DBus.SourceGenerator;
 namespace DBus.Services.Secrets;
 
 /// <summary>
+/// The properties for a particular <see cref="Collection"/>.
+/// </summary>
+public sealed class CollectionProperties
+{
+    /// <summary>
+    /// All items in this <see cref="Collection"/>.
+    /// </summary>
+    public ObjectPath[] Items { get; } = Array.Empty<ObjectPath>();
+
+    /// <summary>
+    /// The displayed label for this <see cref="Collection"/>.
+    /// </summary>
+    public string Label { get; } = string.Empty;
+
+    /// <summary>
+    /// Whether this <see cref="Collection"/> is currently locked or not.
+    /// </summary>
+    public bool Locked { get; }
+
+    /// <summary>
+    /// The unix timestamp of when this <see cref="Collection"/> was created.
+    /// </summary>
+    public DateTimeOffset Created { get; }
+
+    /// <summary>
+    /// The unix timestamp of when this <see cref="Collection"/> was last modified.
+    /// </summary>
+    public DateTimeOffset Modified { get; }
+
+    internal CollectionProperties(OrgFreedesktopSecretCollection.Properties properties)
+    {
+        Items = properties.Items;
+        Label = properties.Label;
+        Locked = properties.Locked;
+        Created = DateTimeOffset.FromUnixTimeSeconds((long)properties.Created);
+        Modified = DateTimeOffset.FromUnixTimeSeconds((long)properties.Modified);
+    }
+}
+
+/// <summary>
 /// Represents a collection of secret items.
 /// </summary>
 public sealed class Collection
@@ -33,6 +73,12 @@ public sealed class Collection
     }
 
     #region D-Bus Properties
+
+    /// <summary>
+    /// Gets all properties for this <see cref="Collection"/>.
+    /// </summary>
+    /// <returns>All properties for this <see cref="Collection"/>.</returns>
+    public async Task<CollectionProperties> GetAllPropertiesAsync() => new CollectionProperties(await _collectionProxy.GetAllPropertiesAsync());
 
     /// <summary>
     /// Gets all <see cref="Item"/>s in this collection.
@@ -68,9 +114,9 @@ public sealed class Collection
     public async Task<ulong> GetCreatedAsync() => await _collectionProxy.GetCreatedPropertyAsync();
 
     /// <summary>
-    /// Gets the unix timestamp of when this <see cref="Collection"/> was modified.
+    /// Gets the unix timestamp of when this <see cref="Collection"/> was last modified.
     /// </summary>
-    /// <returns>The unix timestamp of when this <see cref="Collection"/> was modified.</returns>
+    /// <returns>The unix timestamp of when this <see cref="Collection"/> was last modified.</returns>
     public async Task<ulong> GetModifiedAsync() => await _collectionProxy.GetModifiedPropertyAsync();
 
     #endregion

--- a/src/DBus.Services.Secrets/Collection.cs
+++ b/src/DBus.Services.Secrets/Collection.cs
@@ -111,13 +111,13 @@ public sealed class Collection
     /// Gets the unix timestamp of when this <see cref="Collection"/> was created.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Collection"/> was created.</returns>
-    public async Task<ulong> GetCreatedAsync() => await _collectionProxy.GetCreatedPropertyAsync();
+    public async Task<DateTimeOffset> GetCreatedAsync() => DateTimeOffset.FromUnixTimeSeconds((long) await _collectionProxy.GetCreatedPropertyAsync());
 
     /// <summary>
     /// Gets the unix timestamp of when this <see cref="Collection"/> was last modified.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Collection"/> was last modified.</returns>
-    public async Task<ulong> GetModifiedAsync() => await _collectionProxy.GetModifiedPropertyAsync();
+    public async Task<DateTimeOffset> GetModifiedAsync() => DateTimeOffset.FromUnixTimeSeconds((long) await _collectionProxy.GetModifiedPropertyAsync());
 
     #endregion
 

--- a/src/DBus.Services.Secrets/Item.cs
+++ b/src/DBus.Services.Secrets/Item.cs
@@ -113,13 +113,13 @@ public sealed class Item
     /// Gets the unix timestamp of when this <see cref="Item"/> was created.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Item"/> was created.</returns>
-    public async Task<ulong> GetCreatedAsync() => await _itemProxy.GetCreatedPropertyAsync();
+    public async Task<DateTimeOffset> GetCreatedAsync() => DateTimeOffset.FromUnixTimeSeconds((long) await _itemProxy.GetCreatedPropertyAsync());
 
     /// <summary>
     /// Gets the unix timestamp of when this <see cref="Item"/> was last modified.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Item"/> was last modified.</returns>
-    public async Task<ulong> GetModifiedAsync() => await _itemProxy.GetModifiedPropertyAsync();
+    public async Task<DateTimeOffset> GetModifiedAsync() => DateTimeOffset.FromUnixTimeSeconds((long) await _itemProxy.GetModifiedPropertyAsync());
 
     #endregion
 

--- a/src/DBus.Services.Secrets/Item.cs
+++ b/src/DBus.Services.Secrets/Item.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using DBus.Services.Secrets.Sessions;
@@ -5,6 +6,46 @@ using Tmds.DBus.Protocol;
 using Tmds.DBus.SourceGenerator;
 
 namespace DBus.Services.Secrets;
+
+/// <summary>
+/// The properties for a particular <see cref="Item"/>.
+/// </summary>
+public sealed class ItemProperties
+{
+    /// <summary>
+    /// Whether this <see cref="Item"/> is currently locked.
+    /// </summary>
+    public bool Locked { get; }
+
+    /// <summary>
+    /// The lookup attributes associated with this <see cref="Item"/>.
+    /// </summary>
+    public Dictionary<string, string> Attributes { get; } = new();
+
+    /// <summary>
+    /// The displayed label for this <see cref="Item"/>.
+    /// </summary>
+    public string Label { get; } = string.Empty;
+
+    /// <summary>
+    /// The unix timestamp of when this <see cref="Item"/> was created.
+    /// </summary>
+    public DateTimeOffset Created { get; }
+
+    /// <summary>
+    /// The unix timestamp of when this <see cref="Item"/> was last modified.
+    /// </summary>
+    public DateTimeOffset Modified { get; }
+
+    internal ItemProperties(OrgFreedesktopSecretItem.Properties properties)
+    {
+        Locked = properties.Locked;
+        Attributes = properties.Attributes;
+        Label = properties.Label;
+        Created = DateTimeOffset.FromUnixTimeSeconds((long)properties.Created);
+        Modified = DateTimeOffset.FromUnixTimeSeconds((long)properties.Modified);
+    }
+}
 
 /// <summary>
 /// Represents an item used by the D-Bus secret service.
@@ -31,6 +72,12 @@ public sealed class Item
     }
 
     #region D-Bus Properties
+
+    /// <summary>
+    /// Gets all properties for this <see cref="Item"/>.
+    /// </summary>
+    /// <returns>All properties for this <see cref="Item"/>.</returns>
+    public async Task<ItemProperties> GetAllPropertiesAsync() => new ItemProperties(await _itemProxy.GetAllPropertiesAsync());
 
     /// <summary>
     /// Checks whether this <see cref="Item"/> is currently locked.
@@ -69,9 +116,9 @@ public sealed class Item
     public async Task<ulong> GetCreatedAsync() => await _itemProxy.GetCreatedPropertyAsync();
 
     /// <summary>
-    /// Gets the unix timestamp of when this <see cref="Item"/> was modified.
+    /// Gets the unix timestamp of when this <see cref="Item"/> was last modified.
     /// </summary>
-    /// <returns>The unix timestamp of when this <see cref="Item"/> was modified.</returns>
+    /// <returns>The unix timestamp of when this <see cref="Item"/> was last modified.</returns>
     public async Task<ulong> GetModifiedAsync() => await _itemProxy.GetModifiedPropertyAsync();
 
     #endregion

--- a/src/DBus.Services.Secrets/SecretService.cs
+++ b/src/DBus.Services.Secrets/SecretService.cs
@@ -32,10 +32,18 @@ public sealed class SecretService
     /// Gets all <see cref="Collection"/>s.
     /// </summary>
     /// <returns>An array containing all <see cref="Collection"/>s.</returns>
-    public async Task<Collection[]> GetAllCollectionsAsync() =>
-        (await _serviceProxy.GetCollectionsPropertyAsync())
+    public async Task<Collection[]> GetAllCollectionsAsync()
+    {
+        // TODO: Ideally, we'd be retrieving the properties individually, but this seems to crash?
+        // return (await _serviceProxy.GetCollectionsPropertyAsync())
+        //     .Select(c => new Collection(_connection, _session, c))
+        //     .ToArray();
+
+        return (await _serviceProxy.GetAllPropertiesAsync())
+            .Collections
             .Select(c => new Collection(_connection, _session, c))
             .ToArray();
+    }
 
     #endregion
 

--- a/src/Sandbox/Program.cs
+++ b/src/Sandbox/Program.cs
@@ -14,6 +14,21 @@ public sealed class Program
         SecretService secretService = await SecretService.ConnectAsync(EncryptionType.Dh);
         Console.WriteLine("Connected to D-Bus Secret Service API");
 
+        Console.WriteLine("Available Collections:");
+
+        foreach (Collection collection in await secretService.GetAllCollectionsAsync())
+        {
+            CollectionProperties properties = await collection.GetAllPropertiesAsync();
+
+            Console.WriteLine($"'{properties.Label}' Collection");
+            Console.WriteLine($"- Path: {collection.CollectionPath}");
+            Console.WriteLine($"- Total Items: {properties.Items.Length}");
+            Console.WriteLine($"- Locked? {properties.Locked}");
+            Console.WriteLine($"- Created on {properties.Created}");
+            Console.WriteLine($"- Last modified on {properties.Modified}");
+            Console.WriteLine();
+        }
+
         Console.WriteLine("Retrieving default collection...");
         Collection? defaultCollection = await secretService.GetDefaultCollectionAsync();
 
@@ -58,10 +73,26 @@ public sealed class Program
         {
             foreach (Item item in matchedItems)
             {
-                Console.WriteLine($"Found item at object path {item.ItemPath}");
+                Console.WriteLine($"Found item at {item.ItemPath}");
+
+                // TODO: Reading all properties seem to fail...
+
+                // ItemProperties properties = await item.GetAllPropertiesAsync();
                 byte[] secret = await item.GetSecretAsync();
                 string secretString = Encoding.UTF8.GetString(secret);
-                Console.WriteLine($"Secret Value: {secretString}");
+
+                // Console.WriteLine($"- Label: {properties.Label}");
+                // Console.WriteLine($"- Locked? {properties.Locked}");
+                // Console.WriteLine($"- Created on {properties.Created.ToLocalTime()}");
+                // Console.WriteLine($"- Last modified on {properties.Modified.ToLocalTime()}");
+                // Console.WriteLine($"- Lookup Attributes: {properties.Attributes.Count}");
+
+                // foreach (KeyValuePair<string, string> lookupAttribute in properties.Attributes)
+                // {
+                //     Console.WriteLine($"  - {lookupAttribute.Key}: {lookupAttribute.Value}");
+                // }
+
+                Console.WriteLine($"Decoded Secret Value: {secretString}");
             }
         }
 


### PR DESCRIPTION
Also includes a workaround for a crash when reading all collections and auto-conversion from Unix timestamps to `DateTimeOffset`.

Unfortunately, individual properties still aren't working, and reading all item properties also crashes for some reason... will need to wait for fixes in the source generator and/or protocol library.