### PR TITLE
Update Tmds.DBus.Protocol to 0.21.2 and Tmds.DBus.SourceGenerator to 0.0.21

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.16.0" />
-    <PackageVersion Include="Tmds.DBus.SourceGenerator" Version="0.0.15" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.2" />
+    <PackageVersion Include="Tmds.DBus.SourceGenerator" Version="0.0.21" />
   </ItemGroup>
 </Project>

--- a/src/DBus.Services.Secrets/Constants.cs
+++ b/src/DBus.Services.Secrets/Constants.cs
@@ -1,4 +1,4 @@
-using Tmds.DBus.SourceGenerator;
+using Tmds.DBus.Protocol;
 
 namespace DBus.Services.Secrets;
 
@@ -12,7 +12,7 @@ internal static class Constants
 
     public const string SessionAlgorithmPlain = "plain";
     public const string SessionAlgorithmDh = "dh-ietf1024-sha256-aes128-cbc-pkcs7";
-    public static readonly DBusVariantItem SessionInputPlain = new("s", new DBusStringItem(string.Empty));
+    public static readonly VariantValue SessionInputPlain = VariantValue.String(string.Empty);
 
     public const string CollectionLabelProperty = "org.freedesktop.Secret.Collection.Label";
     public const string DefaultCollectionAlias = "default";

--- a/src/DBus.Services.Secrets/Item.cs
+++ b/src/DBus.Services.Secrets/Item.cs
@@ -37,7 +37,7 @@ public sealed class ItemProperties
     /// </summary>
     public DateTimeOffset Modified { get; }
 
-    internal ItemProperties(OrgFreedesktopSecretItem.Properties properties)
+    internal ItemProperties(OrgFreedesktopSecretItemProxy.OrgFreedesktopSecretItemProperties properties)
     {
         Locked = properties.Locked;
         Attributes = properties.Attributes;
@@ -52,7 +52,7 @@ public sealed class ItemProperties
 /// </summary>
 public sealed class Item
 {
-    private OrgFreedesktopSecretItem _itemProxy;
+    private OrgFreedesktopSecretItemProxy _itemProxy;
 
     private Connection _connection;
     private ISession _session;
@@ -68,7 +68,7 @@ public sealed class Item
         _session = session;
         ItemPath = itemPath;
 
-        _itemProxy = new OrgFreedesktopSecretItem(connection, Constants.ServiceName, itemPath);
+        _itemProxy = new OrgFreedesktopSecretItemProxy(connection, Constants.ServiceName, itemPath);
     }
 
     #region D-Bus Properties

--- a/src/DBus.Services.Secrets/Sessions/PlainSession.cs
+++ b/src/DBus.Services.Secrets/Sessions/PlainSession.cs
@@ -19,7 +19,7 @@ internal sealed class PlainSession : ISession
 
     internal static async Task<PlainSession> OpenPlainSessionAsync(Connection connection)
     {
-        OrgFreedesktopSecretService serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
+        OrgFreedesktopSecretServiceProxy serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
         (_, ObjectPath sessionPath) = await serviceProxy.OpenSessionAsync(Constants.SessionAlgorithmPlain, Constants.SessionInputPlain);
 
         return new PlainSession(sessionPath);

--- a/src/DBus.Services.Secrets/Utilities.cs
+++ b/src/DBus.Services.Secrets/Utilities.cs
@@ -17,7 +17,7 @@ internal static class Utilities
     /// <param name="objectPaths">The <see cref="ObjectPath"/>s to lock or unlock.</param>
     public static async Task LockOrUnlockAsync(Connection connection, bool newLockedValue, params ObjectPath[] objectPaths)
     {
-        OrgFreedesktopSecretService serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
+        OrgFreedesktopSecretServiceProxy serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
 
         (_, ObjectPath promptPath) = newLockedValue switch
         {
@@ -38,10 +38,10 @@ internal static class Utilities
     /// <param name="promptPath">The <see cref="ObjectPath"/> of the prompt.</param>
     /// <param name="windowId">The platform-specific window handle for displaying the prompt. Defaults to an empty string.</param>
     /// <returns>The result of the prompt.</returns>
-    public static async Task<(bool dismissed, DBusVariantItem result)> PromptAsync(Connection connection, ObjectPath promptPath, string windowId = "")
+    public static async Task<(bool dismissed, VariantValue result)> PromptAsync(Connection connection, ObjectPath promptPath, string windowId = "")
     {
-        TaskCompletionSource<(bool, DBusVariantItem)> tcs = new();
-        OrgFreedesktopSecretPrompt promptProxy = new(connection, Constants.ServiceName, promptPath);
+        TaskCompletionSource<(bool, VariantValue)> tcs = new();
+        OrgFreedesktopSecretPromptProxy promptProxy = new(connection, Constants.ServiceName, promptPath);
 
         await promptProxy.WatchCompletedAsync(
             (exception, result) =>


### PR DESCRIPTION
This PR bumps Tmds.DBus.Protocol and Tmds.DBus.SourceGenerator versions to the latest available and makes the required code changes.

Reason to update: DBus.Services.Secrets made recent Avalonia applications crash, because Avalonia pulls the latest version of Tmds.DBus.Protocol/Tmds.DBus.SourceGenerator, while DBus.Services.Secrets references the old versions. My Avalonia projects works fine with the changes in this PR, and the Sandbox project also runs normally.