### PR TITLE
Update Tmds.DBus dependencies + target LTS versions of .NET

### DIFF
--- a/.github/workflows/api-documentation.yml
+++ b/.github/workflows/api-documentation.yml
@@ -30,7 +30,7 @@ jobs:
     - name: .NET Setup
       uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: 9.x
+        dotnet-version: 10.x
 
     - name: Install docfx
       run: dotnet tool update -g docfx

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,9 +22,8 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.x
             8.x
-            9.x
+            10.x
 
       - name: Restore Dependencies
         run: dotnet restore

--- a/.github/workflows/generate-nuget.yml
+++ b/.github/workflows/generate-nuget.yml
@@ -22,9 +22,8 @@ jobs:
         with:
           dotnet-version: |
             6.x
-            7.x
             8.x
-            9.x
+            10.x
 
       - name: Restore Dependencies
         run: dotnet restore

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.2" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
     <PackageVersion Include="Tmds.DBus.SourceGenerator" Version="0.0.22" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -5,6 +5,6 @@
 
   <ItemGroup>
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.2" />
-    <PackageVersion Include="Tmds.DBus.SourceGenerator" Version="0.0.21" />
+    <PackageVersion Include="Tmds.DBus.SourceGenerator" Version="0.0.22" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ These bindings were made using [Tmds.DBus.Protocol](https://github.com/tmds/Tmds
 
 ## Requirements
 
-The bindings currently target .NET 6.0, 7.0, 8.0 and 9.0.
+These bindings require at least .NET 6.0 to work.
 
 ## Basic Usage
 

--- a/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
+++ b/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
@@ -8,7 +8,7 @@
 
     <PackageId>Ace4896.DBus.Services.Secrets</PackageId>
     <Title>DBus.Services.Secrets</Title>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <Description>High-level .NET bindings for the D-Bus Secret Service API.</Description>
     <Summary>High-level .NET bindings for the D-Bus Secret Service API.</Summary>
     <Authors>Jon Pacheco</Authors>

--- a/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
+++ b/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net8.0;net10.0</TargetFrameworks>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
 
     <RootNamespace>DBus.Services.Secrets</RootNamespace>

--- a/src/Sandbox/Sandbox.csproj
+++ b/src/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 


### PR DESCRIPTION
- Update Tmds.DBus.SourceGenerator to 0.0.22
- Update Tmds.DBus.Protocol to 0.21.3
  - New version addresses security issues. Unable to upgrade to 0.92 as source generator hasn't been updated yet
- Only target LTS versions of .NET (at least 6.00
- Bump library version to 1.5.0