### PR TITLE
refactor: Switch to Tmds.DBus.Generator for source code generation

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,8 +2,8 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
+    <PackageVersion Include="Required" Version="1.0.0" />
     <PackageVersion Include="Tmds.DBus.Generator" Version="0.92.0" />
     <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,7 +4,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.21.3" />
-    <PackageVersion Include="Tmds.DBus.SourceGenerator" Version="0.0.22" />
+    <PackageVersion Include="Tmds.DBus.Generator" Version="0.92.0" />
+    <PackageVersion Include="Tmds.DBus.Protocol" Version="0.92.0" />
   </ItemGroup>
 </Project>

--- a/src/DBus.Services.Secrets/Collection.cs
+++ b/src/DBus.Services.Secrets/Collection.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using DBus.Services.Secrets.Sessions;
 using Tmds.DBus.Protocol;
-using Tmds.DBus.SourceGenerator;
 
 namespace DBus.Services.Secrets;
 

--- a/src/DBus.Services.Secrets/Collection.cs
+++ b/src/DBus.Services.Secrets/Collection.cs
@@ -37,16 +37,18 @@ public sealed class CollectionProperties
     /// </summary>
     public DateTimeOffset Modified { get; }
 
-    internal CollectionProperties(OrgFreedesktopSecretCollectionProxy.OrgFreedesktopSecretCollectionProperties properties, DBusConnection connection, ISession session)
+    internal CollectionProperties(Generated.ICollectionProperties properties, DBusConnection connection, ISession session)
     {
-        Items = properties.Items
+        properties.EnsureAllPropertiesSet();
+
+        Items = properties.Items!
             .Select(itemPath => new Item(connection, session, itemPath))
             .ToArray();
 
-        Label = properties.Label;
-        Locked = properties.Locked;
-        Created = DateTimeOffset.FromUnixTimeSeconds((long)properties.Created);
-        Modified = DateTimeOffset.FromUnixTimeSeconds((long)properties.Modified);
+        Label = properties.Label!;
+        Locked = properties.Locked!.Value;
+        Created = DateTimeOffset.FromUnixTimeSeconds((long)properties.Created!.Value);
+        Modified = DateTimeOffset.FromUnixTimeSeconds((long)properties.Modified!.Value);
     }
 }
 
@@ -55,7 +57,7 @@ public sealed class CollectionProperties
 /// </summary>
 public sealed class Collection
 {
-    private OrgFreedesktopSecretCollectionProxy _collectionProxy;
+    private Generated.Collection _collectionProxy;
 
     private DBusConnection _connection;
     private ISession _session;
@@ -71,7 +73,7 @@ public sealed class Collection
         _session = session;
         CollectionPath = collectionPath;
 
-        _collectionProxy = new OrgFreedesktopSecretCollectionProxy(connection, Constants.ServiceName, collectionPath);
+        _collectionProxy = new Generated.Collection(connection, Constants.ServiceName, collectionPath);
     }
 
     #region D-Bus Properties
@@ -80,14 +82,14 @@ public sealed class Collection
     /// Gets all properties for this <see cref="Collection"/>.
     /// </summary>
     /// <returns>All properties for this <see cref="Collection"/>.</returns>
-    public async Task<CollectionProperties> GetAllPropertiesAsync() => new CollectionProperties(await _collectionProxy.GetAllPropertiesAsync(), _connection, _session);
+    public async Task<CollectionProperties> GetAllPropertiesAsync() => new CollectionProperties(await _collectionProxy.GetPropertiesAsync(), _connection, _session);
 
     /// <summary>
     /// Gets all <see cref="Item"/>s in this collection.
     /// </summary>
     /// <returns>An array containing all <see cref="Item"/>s in this collection.</returns>
     public async Task<Item[]> GetItemsAsync() =>
-        (await _collectionProxy.GetItemsPropertyAsync())
+        (await _collectionProxy.GetItemsAsync())
             .Select(itemPath => new Item(_connection, _session, itemPath))
             .ToArray();
 
@@ -95,31 +97,31 @@ public sealed class Collection
     /// Gets the displayed label for this collection.
     /// </summary>
     /// <returns>The displayed label for this collection.</returns>
-    public async Task<string> GetLabelAsync() => await _collectionProxy.GetLabelPropertyAsync();
+    public async Task<string> GetLabelAsync() => await _collectionProxy.GetLabelAsync();
 
     /// <summary>
     /// Sets the displayed label for this collection.
     /// </summary>
     /// <param name="label">The new label to use.</param>
-    public async Task SetLabelAsync(string label) => await _collectionProxy.SetLabelPropertyAsync(label);
+    public async Task SetLabelAsync(string label) => await _collectionProxy.SetLabelAsync(label);
 
     /// <summary>
     /// Checks whether this <see cref="Collection"/> is currently locked.
     /// </summary>
     /// <returns><see langword="true"/> if this <see cref="Collection"/> is currently locked, <see langword="false"/> otherwise.</returns>
-    public async Task<bool> IsLockedAsync() => await _collectionProxy.GetLockedPropertyAsync();
+    public async Task<bool> IsLockedAsync() => await _collectionProxy.GetLockedAsync();
 
     /// <summary>
     /// Gets the unix timestamp of when this <see cref="Collection"/> was created.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Collection"/> was created.</returns>
-    public async Task<DateTimeOffset> GetCreatedAsync() => DateTimeOffset.FromUnixTimeSeconds((long)await _collectionProxy.GetCreatedPropertyAsync());
+    public async Task<DateTimeOffset> GetCreatedAsync() => DateTimeOffset.FromUnixTimeSeconds((long)await _collectionProxy.GetCreatedAsync());
 
     /// <summary>
     /// Gets the unix timestamp of when this <see cref="Collection"/> was last modified.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Collection"/> was last modified.</returns>
-    public async Task<DateTimeOffset> GetModifiedAsync() => DateTimeOffset.FromUnixTimeSeconds((long)await _collectionProxy.GetModifiedPropertyAsync());
+    public async Task<DateTimeOffset> GetModifiedAsync() => DateTimeOffset.FromUnixTimeSeconds((long)await _collectionProxy.GetModifiedAsync());
 
     #endregion
 

--- a/src/DBus.Services.Secrets/Collection.cs
+++ b/src/DBus.Services.Secrets/Collection.cs
@@ -38,7 +38,7 @@ public sealed class CollectionProperties
     /// </summary>
     public DateTimeOffset Modified { get; }
 
-    internal CollectionProperties(OrgFreedesktopSecretCollectionProxy.OrgFreedesktopSecretCollectionProperties properties, Connection connection, ISession session)
+    internal CollectionProperties(OrgFreedesktopSecretCollectionProxy.OrgFreedesktopSecretCollectionProperties properties, DBusConnection connection, ISession session)
     {
         Items = properties.Items
             .Select(itemPath => new Item(connection, session, itemPath))
@@ -58,7 +58,7 @@ public sealed class Collection
 {
     private OrgFreedesktopSecretCollectionProxy _collectionProxy;
 
-    private Connection _connection;
+    private DBusConnection _connection;
     private ISession _session;
 
     /// <value>
@@ -66,7 +66,7 @@ public sealed class Collection
     /// </value>
     public ObjectPath CollectionPath { get; }
 
-    internal Collection(Connection connection, ISession session, ObjectPath collectionPath)
+    internal Collection(DBusConnection connection, ISession session, ObjectPath collectionPath)
     {
         _connection = connection;
         _session = session;

--- a/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
+++ b/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
@@ -27,5 +27,8 @@
   <ItemGroup>
     <PackageReference Include="Tmds.DBus.Generator" />
     <PackageReference Include="Tmds.DBus.Protocol" />
+
+    <!-- For .NET 6 compatibility -->
+    <PackageReference Include="Required" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
+++ b/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
@@ -20,12 +20,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <AdditionalFiles Include="./xml/org.freedesktop.secrets.xml" DBusGeneratorMode="Proxy" />
+    <AdditionalFiles Include="./xml/org.freedesktop.secrets.xml" Namespace="DBus.Services.Secrets.Generated" GenerateDBusTypes="true" />
     <None Include="../../README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Tmds.DBus.Generator" />
     <PackageReference Include="Tmds.DBus.Protocol" />
-    <PackageReference Include="Tmds.DBus.SourceGenerator" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
+++ b/src/DBus.Services.Secrets/DBus.Services.Secrets.csproj
@@ -8,7 +8,7 @@
 
     <PackageId>Ace4896.DBus.Services.Secrets</PackageId>
     <Title>DBus.Services.Secrets</Title>
-    <Version>1.5.0</Version>
+    <Version>1.6.0</Version>
     <Description>High-level .NET bindings for the D-Bus Secret Service API.</Description>
     <Summary>High-level .NET bindings for the D-Bus Secret Service API.</Summary>
     <Authors>Jon Pacheco</Authors>

--- a/src/DBus.Services.Secrets/Item.cs
+++ b/src/DBus.Services.Secrets/Item.cs
@@ -54,7 +54,7 @@ public sealed class Item
 {
     private OrgFreedesktopSecretItemProxy _itemProxy;
 
-    private Connection _connection;
+    private DBusConnection _connection;
     private ISession _session;
 
     /// <value>
@@ -62,7 +62,7 @@ public sealed class Item
     /// </value>
     public ObjectPath ItemPath { get; }
 
-    internal Item(Connection connection, ISession session, ObjectPath itemPath)
+    internal Item(DBusConnection connection, ISession session, ObjectPath itemPath)
     {
         _connection = connection;
         _session = session;

--- a/src/DBus.Services.Secrets/Item.cs
+++ b/src/DBus.Services.Secrets/Item.cs
@@ -36,13 +36,15 @@ public sealed class ItemProperties
     /// </summary>
     public DateTimeOffset Modified { get; }
 
-    internal ItemProperties(OrgFreedesktopSecretItemProxy.OrgFreedesktopSecretItemProperties properties)
+    internal ItemProperties(Generated.IItemProperties properties)
     {
-        Locked = properties.Locked;
-        Attributes = properties.Attributes;
-        Label = properties.Label;
-        Created = DateTimeOffset.FromUnixTimeSeconds((long)properties.Created);
-        Modified = DateTimeOffset.FromUnixTimeSeconds((long)properties.Modified);
+        properties.EnsureAllPropertiesSet();
+
+        Locked = properties.Locked!.Value;
+        Attributes = properties.Attributes!;
+        Label = properties.Label!;
+        Created = DateTimeOffset.FromUnixTimeSeconds((long)properties.Created!.Value);
+        Modified = DateTimeOffset.FromUnixTimeSeconds((long)properties.Modified!.Value);
     }
 }
 
@@ -51,7 +53,7 @@ public sealed class ItemProperties
 /// </summary>
 public sealed class Item
 {
-    private OrgFreedesktopSecretItemProxy _itemProxy;
+    private Generated.Item _itemProxy;
 
     private DBusConnection _connection;
     private ISession _session;
@@ -67,7 +69,7 @@ public sealed class Item
         _session = session;
         ItemPath = itemPath;
 
-        _itemProxy = new OrgFreedesktopSecretItemProxy(connection, Constants.ServiceName, itemPath);
+        _itemProxy = new Generated.Item(connection, Constants.ServiceName, itemPath);
     }
 
     #region D-Bus Properties
@@ -76,49 +78,49 @@ public sealed class Item
     /// Gets all properties for this <see cref="Item"/>.
     /// </summary>
     /// <returns>All properties for this <see cref="Item"/>.</returns>
-    public async Task<ItemProperties> GetAllPropertiesAsync() => new ItemProperties(await _itemProxy.GetAllPropertiesAsync());
+    public async Task<ItemProperties> GetAllPropertiesAsync() => new ItemProperties(await _itemProxy.GetPropertiesAsync());
 
     /// <summary>
     /// Checks whether this <see cref="Item"/> is currently locked.
     /// </summary>
     /// <returns><see langword="true"/> if this <see cref="Item"/> is currently locked, <see langword="false"/> otherwise.</returns>
-    public async Task<bool> IsLockedAsync() => await _itemProxy.GetLockedPropertyAsync();
+    public async Task<bool> IsLockedAsync() => await _itemProxy.GetLockedAsync();
 
     /// <summary>
     /// Gets the lookup attributes associated with this <see cref="Item"/>.
     /// </summary>
     /// <returns>The lookup attributes associated with this <see cref="Item"/>.</returns>
-    public async Task<Dictionary<string, string>> GetLookupAttributesAsync() => await _itemProxy.GetAttributesPropertyAsync();
+    public async Task<Dictionary<string, string>> GetLookupAttributesAsync() => await _itemProxy.GetAttributesAsync();
 
     /// <summary>
     /// Sets the lookup attributes associated with this <see cref="Item"/>.
     /// </summary>
     /// <param name="lookupAttributes">The new lookup attributes associated with this <see cref="Item"/>.</param>
-    public async Task SetLookupAttributesAsync(Dictionary<string, string> lookupAttributes) => await _itemProxy.SetAttributesPropertyAsync(lookupAttributes);
+    public async Task SetLookupAttributesAsync(Dictionary<string, string> lookupAttributes) => await _itemProxy.SetAttributesAsync(lookupAttributes);
 
     /// <summary>
     /// Gets the displayed label for this <see cref="Item"/>.
     /// </summary>
     /// <returns>The displayed label for this <see cref="Item"/>.</returns>
-    public async Task<string> GetLabelAsync() => await _itemProxy.GetLabelPropertyAsync();
+    public async Task<string> GetLabelAsync() => await _itemProxy.GetLabelAsync();
 
     /// <summary>
     /// Sets the displayed label for this <see cref="Item"/>.
     /// </summary>
     /// <param name="label">The new displayed label for this <see cref="Item"/>.</param>
-    public async Task SetLabelAsync(string label) => await _itemProxy.SetLabelPropertyAsync(label);
+    public async Task SetLabelAsync(string label) => await _itemProxy.SetLabelAsync(label);
 
     /// <summary>
     /// Gets the unix timestamp of when this <see cref="Item"/> was created.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Item"/> was created.</returns>
-    public async Task<DateTimeOffset> GetCreatedAsync() => DateTimeOffset.FromUnixTimeSeconds((long) await _itemProxy.GetCreatedPropertyAsync());
+    public async Task<DateTimeOffset> GetCreatedAsync() => DateTimeOffset.FromUnixTimeSeconds((long)await _itemProxy.GetCreatedAsync());
 
     /// <summary>
     /// Gets the unix timestamp of when this <see cref="Item"/> was last modified.
     /// </summary>
     /// <returns>The unix timestamp of when this <see cref="Item"/> was last modified.</returns>
-    public async Task<DateTimeOffset> GetModifiedAsync() => DateTimeOffset.FromUnixTimeSeconds((long) await _itemProxy.GetModifiedPropertyAsync());
+    public async Task<DateTimeOffset> GetModifiedAsync() => DateTimeOffset.FromUnixTimeSeconds((long)await _itemProxy.GetModifiedAsync());
 
     #endregion
 

--- a/src/DBus.Services.Secrets/Item.cs
+++ b/src/DBus.Services.Secrets/Item.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using DBus.Services.Secrets.Sessions;
 using Tmds.DBus.Protocol;
-using Tmds.DBus.SourceGenerator;
 
 namespace DBus.Services.Secrets;
 

--- a/src/DBus.Services.Secrets/SecretService.cs
+++ b/src/DBus.Services.Secrets/SecretService.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using DBus.Services.Secrets.Sessions;
 using Tmds.DBus.Protocol;
-using Tmds.DBus.SourceGenerator;
 
 namespace DBus.Services.Secrets;
 

--- a/src/DBus.Services.Secrets/SecretService.cs
+++ b/src/DBus.Services.Secrets/SecretService.cs
@@ -15,10 +15,10 @@ public sealed class SecretService
 {
     private OrgFreedesktopSecretServiceProxy _serviceProxy;
 
-    private Connection _connection;
+    private DBusConnection _connection;
     private ISession _session;
 
-    internal SecretService(Connection connection, ISession session)
+    internal SecretService(DBusConnection connection, ISession session)
     {
         _connection = connection;
         _session = session;
@@ -48,7 +48,7 @@ public sealed class SecretService
     /// <returns>A new instance of the <see cref="SecretService"/> class.</returns>
     public static async Task<SecretService> ConnectAsync(EncryptionType encryptionType)
     {
-        Connection connection = new(Address.Session!);
+        DBusConnection connection = new(Address.Session!);
         await connection.ConnectAsync();
 
         // Open a new session based on the specified encryption type

--- a/src/DBus.Services.Secrets/SecretService.cs
+++ b/src/DBus.Services.Secrets/SecretService.cs
@@ -48,7 +48,7 @@ public sealed class SecretService
     /// <returns>A new instance of the <see cref="SecretService"/> class.</returns>
     public static async Task<SecretService> ConnectAsync(EncryptionType encryptionType)
     {
-        DBusConnection connection = new(Address.Session!);
+        DBusConnection connection = new(DBusAddress.Session!);
         await connection.ConnectAsync();
 
         // Open a new session based on the specified encryption type

--- a/src/DBus.Services.Secrets/SecretService.cs
+++ b/src/DBus.Services.Secrets/SecretService.cs
@@ -12,7 +12,7 @@ namespace DBus.Services.Secrets;
 /// </summary>
 public sealed class SecretService
 {
-    private OrgFreedesktopSecretServiceProxy _serviceProxy;
+    private Generated.Service _serviceProxy;
 
     private DBusConnection _connection;
     private ISession _session;
@@ -22,7 +22,7 @@ public sealed class SecretService
         _connection = connection;
         _session = session;
 
-        _serviceProxy = new OrgFreedesktopSecretServiceProxy(connection, Constants.ServiceName, Constants.ServicePath);
+        _serviceProxy = new Generated.Service(connection, Constants.ServiceName, Constants.ServicePath);
     }
 
     #region D-Bus Properties
@@ -32,7 +32,7 @@ public sealed class SecretService
     /// </summary>
     /// <returns>An array containing all <see cref="Collection"/>s.</returns>
     public async Task<Collection[]> GetAllCollectionsAsync() =>
-        (await _serviceProxy.GetCollectionsPropertyAsync())
+        (await _serviceProxy.GetCollectionsAsync())
             .Select(c => new Collection(_connection, _session, c))
             .ToArray();
 

--- a/src/DBus.Services.Secrets/Sessions/DhSession.cs
+++ b/src/DBus.Services.Secrets/Sessions/DhSession.cs
@@ -23,7 +23,7 @@ internal sealed class DhSession : ISession
 
     internal static async Task<DhSession> OpenDhSessionAsync(DBusConnection connection)
     {
-        OrgFreedesktopSecretServiceProxy serviceProxy = new OrgFreedesktopSecretServiceProxy(connection, Constants.ServiceName, Constants.ServicePath);
+        Generated.Service serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
 
         // Input for a DH encrypted session is our DH public key
         // Output from OpenSession call is service's DH public key

--- a/src/DBus.Services.Secrets/Sessions/DhSession.cs
+++ b/src/DBus.Services.Secrets/Sessions/DhSession.cs
@@ -3,7 +3,6 @@ using System.Numerics;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Tmds.DBus.Protocol;
-using Tmds.DBus.SourceGenerator;
 
 namespace DBus.Services.Secrets.Sessions;
 

--- a/src/DBus.Services.Secrets/Sessions/DhSession.cs
+++ b/src/DBus.Services.Secrets/Sessions/DhSession.cs
@@ -22,7 +22,7 @@ internal sealed class DhSession : ISession
         _aesKey = aesKey;
     }
 
-    internal static async Task<DhSession> OpenDhSessionAsync(Connection connection)
+    internal static async Task<DhSession> OpenDhSessionAsync(DBusConnection connection)
     {
         OrgFreedesktopSecretServiceProxy serviceProxy = new OrgFreedesktopSecretServiceProxy(connection, Constants.ServiceName, Constants.ServicePath);
 

--- a/src/DBus.Services.Secrets/Sessions/PlainSession.cs
+++ b/src/DBus.Services.Secrets/Sessions/PlainSession.cs
@@ -18,7 +18,7 @@ internal sealed class PlainSession : ISession
 
     internal static async Task<PlainSession> OpenPlainSessionAsync(DBusConnection connection)
     {
-        OrgFreedesktopSecretServiceProxy serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
+        Generated.Service serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
         (_, ObjectPath sessionPath) = await serviceProxy.OpenSessionAsync(Constants.SessionAlgorithmPlain, Constants.SessionInputPlain);
 
         return new PlainSession(sessionPath);

--- a/src/DBus.Services.Secrets/Sessions/PlainSession.cs
+++ b/src/DBus.Services.Secrets/Sessions/PlainSession.cs
@@ -17,7 +17,7 @@ internal sealed class PlainSession : ISession
         SessionPath = sessionPath;
     }
 
-    internal static async Task<PlainSession> OpenPlainSessionAsync(Connection connection)
+    internal static async Task<PlainSession> OpenPlainSessionAsync(DBusConnection connection)
     {
         OrgFreedesktopSecretServiceProxy serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
         (_, ObjectPath sessionPath) = await serviceProxy.OpenSessionAsync(Constants.SessionAlgorithmPlain, Constants.SessionInputPlain);

--- a/src/DBus.Services.Secrets/Sessions/PlainSession.cs
+++ b/src/DBus.Services.Secrets/Sessions/PlainSession.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Threading.Tasks;
 using Tmds.DBus.Protocol;
-using Tmds.DBus.SourceGenerator;
 
 namespace DBus.Services.Secrets.Sessions;
 

--- a/src/DBus.Services.Secrets/Utilities.cs
+++ b/src/DBus.Services.Secrets/Utilities.cs
@@ -12,10 +12,10 @@ internal static class Utilities
     /// <summary>
     /// Locks or unlocks the specified object paths, prompting the user where necessary.
     /// </summary>
-    /// <param name="connection">The current <see cref="Connection"/>.</param>
+    /// <param name="connection">The current <see cref="DBusConnection"/>.</param>
     /// <param name="newLockedValue">Whether the items should be locked or unlocked.</param>
     /// <param name="objectPaths">The <see cref="ObjectPath"/>s to lock or unlock.</param>
-    public static async Task LockOrUnlockAsync(Connection connection, bool newLockedValue, params ObjectPath[] objectPaths)
+    public static async Task LockOrUnlockAsync(DBusConnection connection, bool newLockedValue, params ObjectPath[] objectPaths)
     {
         OrgFreedesktopSecretServiceProxy serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
 
@@ -34,11 +34,11 @@ internal static class Utilities
     /// <summary>
     /// Displays a prompt required by the secret service using the specified window handle.
     /// </summary>
-    /// <param name="connection">The current <see cref="Connection"/> in use.</param>
+    /// <param name="connection">The current <see cref="DBusConnection"/> in use.</param>
     /// <param name="promptPath">The <see cref="ObjectPath"/> of the prompt.</param>
     /// <param name="windowId">The platform-specific window handle for displaying the prompt. Defaults to an empty string.</param>
     /// <returns>The result of the prompt.</returns>
-    public static async Task<(bool dismissed, VariantValue result)> PromptAsync(Connection connection, ObjectPath promptPath, string windowId = "")
+    public static async Task<(bool dismissed, VariantValue result)> PromptAsync(DBusConnection connection, ObjectPath promptPath, string windowId = "")
     {
         TaskCompletionSource<(bool, VariantValue)> tcs = new();
         OrgFreedesktopSecretPromptProxy promptProxy = new(connection, Constants.ServiceName, promptPath);

--- a/src/DBus.Services.Secrets/Utilities.cs
+++ b/src/DBus.Services.Secrets/Utilities.cs
@@ -1,6 +1,5 @@
 using System.Threading.Tasks;
 using Tmds.DBus.Protocol;
-using Tmds.DBus.SourceGenerator;
 
 namespace DBus.Services.Secrets;
 

--- a/src/DBus.Services.Secrets/Utilities.cs
+++ b/src/DBus.Services.Secrets/Utilities.cs
@@ -16,7 +16,7 @@ internal static class Utilities
     /// <param name="objectPaths">The <see cref="ObjectPath"/>s to lock or unlock.</param>
     public static async Task LockOrUnlockAsync(DBusConnection connection, bool newLockedValue, params ObjectPath[] objectPaths)
     {
-        OrgFreedesktopSecretServiceProxy serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
+        Generated.Service serviceProxy = new(connection, Constants.ServiceName, Constants.ServicePath);
 
         (_, ObjectPath promptPath) = newLockedValue switch
         {
@@ -40,7 +40,7 @@ internal static class Utilities
     public static async Task<(bool dismissed, VariantValue result)> PromptAsync(DBusConnection connection, ObjectPath promptPath, string windowId = "")
     {
         TaskCompletionSource<(bool, VariantValue)> tcs = new();
-        OrgFreedesktopSecretPromptProxy promptProxy = new(connection, Constants.ServiceName, promptPath);
+        Generated.Prompt promptProxy = new(connection, Constants.ServiceName, promptPath);
 
         await promptProxy.WatchCompletedAsync(
             (exception, result) =>


### PR DESCRIPTION
Replaces `Tmds.DBus.SourceGenerator` with `Tmds.DBus.Generator`. This required upgrading `Tmds.DBus.Protocol` to 0.92.0. Generated API is almost identical - main difference is the ability to change namespace and nullable attributes when retrieving all properties at the same time.

Also bump package version to 1.6.0.

Closes #24 