### PR TITLE
ci(renovate): disable abandonment warning for 'Required' package on NuGet

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,10 +6,17 @@
   "minimumReleaseAge": "2 weeks",
   "packageRules": [
     {
-      "groupName": "Tmds.DBus Packages",
-      "groupSlug": "tmds-dbus",
       "description": "Group Tmds.DBus package updates",
-      "matchPackageNames": ["Tmds.DBus**"]
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["Tmds.DBus**"],
+      "groupName": "Tmds.DBus Packages",
+      "groupSlug": "tmds-dbus"
+    },
+    {
+      "description": "Disable abandonment warning for 'Required' package on NuGet (considered feature-complete)",
+      "matchDatasources": ["nuget"],
+      "matchPackageNames": ["Required"],
+      "abandonmentThreshold": null
     }
   ]
 }


### PR DESCRIPTION
Disables the abandonment warning for the `Required` package on NuGet by setting the abandonment threshold to `null` ( as described in [renovate documentation](https://docs.renovatebot.com/configuration-options/#abandonmentthreshold))

Also specify `nuget` datasource in package rules.